### PR TITLE
The directory of the file is now watched by inotify.

### DIFF
--- a/graphwiz.py
+++ b/graphwiz.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # Copyright 2008 Jose Fonseca
 #


### PR DESCRIPTION
Since many editors rewrite the complete file and the filehandle
changes the file wont be tracked anymore by inotify. So it's
safer to track the parent directory and filter the messages
by filename.
